### PR TITLE
Renamed MLX module and redid strings for it

### DIFF
--- a/stmhal/mpconfigport.h
+++ b/stmhal/mpconfigport.h
@@ -109,10 +109,10 @@ extern const struct _mp_obj_module_t mp_module_network;
 extern const struct _mp_obj_module_t time_module;
 extern const struct _mp_obj_module_t sensor_module;
 extern const struct _mp_obj_module_t image_module;
+extern const struct _mp_obj_module_t lcd_module;
+extern const struct _mp_obj_module_t flir_module;
 extern const struct _mp_obj_module_t gif_module;
 extern const struct _mp_obj_module_t mjpeg_module;
-extern const struct _mp_obj_module_t lcd_module;
-extern const struct _mp_obj_module_t mlx_module;
 
 #define MICROPY_PORT_BUILTIN_MODULES \
     { MP_OBJ_NEW_QSTR(MP_QSTR_pyb),     (mp_obj_t)&pyb_module }, \
@@ -125,10 +125,10 @@ extern const struct _mp_obj_module_t mlx_module;
     { MP_OBJ_NEW_QSTR(MP_QSTR_time),    (mp_obj_t)&time_module }, \
     { MP_OBJ_NEW_QSTR(MP_QSTR_sensor),  (mp_obj_t)&sensor_module }, \
     { MP_OBJ_NEW_QSTR(MP_QSTR_image),   (mp_obj_t)&image_module }, \
+    { MP_OBJ_NEW_QSTR(MP_QSTR_lcd),     (mp_obj_t)&lcd_module }, \
+    { MP_OBJ_NEW_QSTR(MP_QSTR_flir),    (mp_obj_t)&flir_module }, \
     { MP_OBJ_NEW_QSTR(MP_QSTR_gif),     (mp_obj_t)&gif_module }, \
     { MP_OBJ_NEW_QSTR(MP_QSTR_mjpeg),   (mp_obj_t)&mjpeg_module }, \
-    { MP_OBJ_NEW_QSTR(MP_QSTR_lcd),     (mp_obj_t)&lcd_module }, \
-    { MP_OBJ_NEW_QSTR(MP_QSTR_mlx),     (mp_obj_t)&mlx_module },
 
 #define MICROPY_PORT_BUILTIN_MODULE_WEAK_LINKS \
     { MP_OBJ_NEW_QSTR(MP_QSTR_os), (mp_obj_t)&mp_module_uos }, \

--- a/stmhal/qstrdefsport.h
+++ b/stmhal/qstrdefsport.h
@@ -766,7 +766,6 @@ Q(lbp_desc)
 Q(Cascade)
 Q(blit)
 Q(blend)
-Q(scale)
 Q(scaled)
 Q(subimg)
 Q(compress)
@@ -800,18 +799,6 @@ Q(load_descriptor)
 Q(save_descriptor)
 Q(match_descriptor)
 
-// Gif module
-Q(gif)
-Q(Gif)
-Q(open)
-Q(add_frame)
-Q(close)
-Q(loop)
-
-// Mjpeg module
-Q(mjpeg)
-Q(Mjpeg)
-
 // Lcd Module
 Q(lcd)
 Q(type)
@@ -819,6 +806,26 @@ Q(set_backlight)
 Q(get_backlight)
 Q(display)
 Q(clear)
+
+// Flir Module
+Q(flir)
+Q(read_ta)
+Q(read_ir)
+Q(display_ta)
+Q(display_ir)
+Q(alpha)
+Q(scale)
+
+// Gif module
+Q(gif)
+Q(Gif)
+Q(open)
+Q(add_frame)
+Q(loop)
+
+// Mjpeg module
+Q(mjpeg)
+Q(Mjpeg)
 
 // Led Module
 Q(led)
@@ -958,20 +965,3 @@ Q(IPPROTO_TCP)
 Q(IPPROTO_UDP)
 Q(IPPROTO_IPV6)
 Q(IPPROTO_RAW)
-
-// MLX90620
-Q(mlx)
-Q(init)
-Q(read_ta)
-Q(read_ir)
-Q(read_raw)
-Q(RAINBOW)
-Q(GRAYSCALE)
-Q(GRAYSCALE)
-Q(IR_REFRESH_8HZ)
-Q(IR_REFRESH_16HZ)
-Q(IR_REFRESH_32HZ)
-Q(IR_REFRESH_64HZ)
-Q(IR_REFRESH_128HZ)
-Q(IR_REFRESH_256HZ)
-Q(IR_REFRESH_512HZ)


### PR DESCRIPTION
The refresh rate strings have been removed because no simple user will care about that. I set the refresh rate to above 60HZ which you can't hit above with our system. As for rainbow and grayscale, the new code just blends rainbow if the image is RGB565 and grayscale if the image is grayscale. 
