### PR TITLE
Linked in fb_alloc_mark

### DIFF
--- a/py/nlr.h
+++ b/py/nlr.h
@@ -85,11 +85,32 @@ NORETURN void nlr_jump(void *val);
 void nlr_jump_fail(void *val);
 
 // use nlr_raise instead of nlr_jump so that debugging is easier
+extern void fb_alloc_free_till_mark();
 #ifndef DEBUG
-#define nlr_raise(val) nlr_jump(MP_OBJ_TO_PTR(val))
+#define nlr_raise(val) \
+    do { \
+        fb_alloc_free_till_mark(); \
+        nlr_jump(MP_OBJ_TO_PTR(val)); \
+    } while (0)
+// fb_alloc_mark() is the only allowed caller.
+#define nlr_raise_for_fb_alloc_mark(val) \
+    do { \
+        nlr_jump(MP_OBJ_TO_PTR(val)); \
+    } while (0)
 #else
 #include "mpstate.h"
 #define nlr_raise(val) \
+    do { \
+        fb_alloc_free_till_mark(); \
+        /*printf("nlr_raise: nlr_top=%p\n", MP_STATE_VM(nlr_top)); \
+        fflush(stdout);*/ \
+        void *_val = MP_OBJ_TO_PTR(val); \
+        assert(_val != NULL); \
+        assert(mp_obj_is_exception_instance(val)); \
+        nlr_jump(_val); \
+    } while (0)
+// fb_alloc_mark() is the only allowed caller.
+#define nlr_raise_for_fb_alloc_mark(val) \
     do { \
         /*printf("nlr_raise: nlr_top=%p\n", MP_STATE_VM(nlr_top)); \
         fflush(stdout);*/ \


### PR DESCRIPTION
Tested it and nothing breaks. Note that it's important all of the code calls the nlr_raise macro wrapper around nlr_jump. There are a few places in our code where that isn't the case and will have to be fixed.

Note the second version of the macro is for fb_alloc_mark which has to fail without unwinding the alloc stack since a mark hasn't be placed yet.