### PR TITLE
added dummy fb_alloc_free_till_mark function.

### DIFF
--- a/py/omvdummy.c
+++ b/py/omvdummy.c
@@ -1,0 +1,16 @@
+/*
+ * omvdummy.c
+ */
+
+/*
+ * This function is doesn't to do anything.
+ * It stay here to prevent the error when compiling 
+ * a frozen module on openmv platform.
+ * It declared as weak function and when all compiled 
+ * objects have been linked, it will override by 
+ * the real 'fb_alloc_free_till_mark' function 
+ * which in 'fb_alloc.c' files
+ */
+void __attribute__((weak)) fb_alloc_free_till_mark()
+{
+}

--- a/py/py.mk
+++ b/py/py.mk
@@ -214,6 +214,7 @@ PY_CORE_O_BASENAME = $(addprefix py/,\
 	repl.o \
 	smallint.o \
 	frozenmod.o \
+	omvdummy.o \
 	)
 
 PY_EXTMOD_O_BASENAME = \


### PR DESCRIPTION
added dummy `fb_alloc_free_till_mark` function to prevent error "undefined reference to fb_alloc_free_till_mark" when compiling a frozen module.