### PR TITLE
Fix SPI DMA issues on the H7

### DIFF
--- a/ports/stm32/dma.h
+++ b/ports/stm32/dma.h
@@ -105,10 +105,16 @@ extern const dma_descr_t dma_I2C_4_RX;
 // NOTE: F4 CCM memory is not accessible by GP-DMA.
 #define DMA_BUFFER(p)       ((((uint32_t)p & 3) == 0) && ((uint32_t) p > 0x10010000))
 #elif defined(STM32H7)
-// NOTE: H7 SD DMA can only access AXI SRAM memory.
-#define DMA_BUFFER(p)       ((((uint32_t)p & 3) == 0) && ((uint32_t) p >= 0x24000000) && ((uint32_t) p < 0x24080000))
+#define DMA_BUFFER(p)       (((uint32_t)p & 3) == 0)
 #else
 #error Unsupported processor
+#endif
+
+// NOTE: H7 SD DMA can only access AXI SRAM memory.
+#if !defined(STM32H7)
+    #define IS_AXI_SRAM(p)      (1)
+#else
+    #define IS_AXI_SRAM(p)      ((uint32_t) p >= 0x24000000) && ((uint32_t) p < 0x24080000)
 #endif
 
 void dma_init(DMA_HandleTypeDef *dma, const dma_descr_t *dma_descr, uint32_t dir, void *data);

--- a/ports/stm32/sdcard.c
+++ b/ports/stm32/sdcard.c
@@ -499,7 +499,7 @@ mp_uint_t sdcard_read_blocks(uint8_t *dest, uint32_t block_num, uint32_t num_blo
     // we must disable USB irqs to prevent MSC contention with SD card
     uint32_t basepri = raise_irq_pri(IRQ_PRI_OTG_FS);
 
-    if (query_irq() == IRQ_STATE_ENABLED && DMA_BUFFER(dest)) {
+    if (query_irq() == IRQ_STATE_ENABLED && DMA_BUFFER(dest) && IS_AXI_SRAM(dest)) {
         #if SDIO_USE_GPDMA
         DMA_HandleTypeDef sd_dma;
         dma_init(&sd_dma, &SDMMC_DMA, DMA_PERIPH_TO_MEMORY, &sdmmc_handle);
@@ -576,7 +576,7 @@ mp_uint_t sdcard_write_blocks(const uint8_t *src, uint32_t block_num, uint32_t n
     // we must disable USB irqs to prevent MSC contention with SD card
     uint32_t basepri = raise_irq_pri(IRQ_PRI_OTG_FS);
 
-    if (query_irq() == IRQ_STATE_ENABLED && DMA_BUFFER(src)) {
+    if (query_irq() == IRQ_STATE_ENABLED && DMA_BUFFER(src) && IS_AXI_SRAM(src)) {
         #if SDIO_USE_GPDMA
         DMA_HandleTypeDef sd_dma;
         dma_init(&sd_dma, &SDMMC_DMA, DMA_MEMORY_TO_PERIPH, &sdmmc_handle);


### PR DESCRIPTION
This fix makes SPI DMA transfers work on the H7 if you do something like:

```
    def _get_bytes(self, nbytes, timeout_ms): # protected
        result = None
        self.__spi.init(pyb.SPI.SLAVE, polarity=self.__polarity, phase=self.__clk_phase)
        try: result = self.__spi.send_recv(bytes(nbytes), timeout=timeout_ms)
        except OSError: pass
        self.__spi.deinit()
        return result

    def _put_bytes(self, data, timeout_ms): # protected
        self.__spi.init(pyb.SPI.SLAVE, polarity=self.__polarity, phase=self.__clk_phase)
        try: self.__spi.send(data, timeout=timeout_ms)
        except OSError: pass
        self.__spi.deinit()
```

It's not a perfect fix because the DMA hardware on the H7 is bugged... but, it works for all cases we need without issues. If the H7 wasn't bugged you wouldn't need to deinit and init the bus each transfer which is kinda ugly.