### PR TITLE
Disable SPI/I2C DMA on restart to prevent crash

### DIFF
--- a/ports/stm32/dma.c
+++ b/ports/stm32/dma.c
@@ -776,6 +776,7 @@ void dma_init(DMA_HandleTypeDef *dma, const dma_descr_t *dma_descr, uint32_t dir
 
 void dma_deinit(const dma_descr_t *dma_descr) {
     if (dma_descr != NULL) {
+        HAL_DMA_Abort(dma_handle[dma_descr->id]);
         #if !defined(STM32F0)
         HAL_NVIC_DisableIRQ(dma_irqn[dma_descr->id]);
         #endif

--- a/ports/stm32/i2c.h
+++ b/ports/stm32/i2c.h
@@ -47,6 +47,7 @@ extern const mp_obj_type_t pyb_i2c_type;
 extern const pyb_i2c_obj_t pyb_i2c_obj[4];
 
 void i2c_init0(void);
+void i2c_deinit_all(void);
 void pyb_i2c_init(I2C_HandleTypeDef *i2c);
 void pyb_i2c_init_freq(const pyb_i2c_obj_t *self, mp_int_t freq);
 uint32_t pyb_i2c_get_baudrate(I2C_HandleTypeDef *i2c);

--- a/ports/stm32/pyb_i2c.c
+++ b/ports/stm32/pyb_i2c.c
@@ -340,6 +340,12 @@ void pyb_i2c_init(I2C_HandleTypeDef *i2c) {
 }
 
 void i2c_deinit(I2C_HandleTypeDef *i2c) {
+    if (pyb_i2c->rx_dma_descr != NULL) {
+        dma_deinit(pyb_i2c->rx_dma_descr);
+    }
+    if (pyb_i2c->tx_dma_descr != NULL) {
+        dma_deinit(pyb_i2c->tx_dma_descr);
+    }
     HAL_I2C_DeInit(i2c);
     if (0) {
     #if defined(MICROPY_HW_I2C1_SCL)
@@ -374,6 +380,15 @@ void i2c_deinit(I2C_HandleTypeDef *i2c) {
         HAL_NVIC_DisableIRQ(I2C4_EV_IRQn);
         HAL_NVIC_DisableIRQ(I2C4_ER_IRQn);
     #endif
+    }
+}
+
+void i2c_deinit_all(void) {
+    for (int i = 0; i < (sizeof(pyb_i2c_obj) / sizeof(pyb_i2c_obj_t)); i++) {
+        const pyb_i2c_obj_t *pyb_i2c = &pyb_i2c_obj[i];
+        if (pyb_i2c->i2c != NULL) {
+            i2c_deinit(pyb_i2c->i2c);
+        }
     }
 }
 

--- a/ports/stm32/spi.c
+++ b/ports/stm32/spi.c
@@ -142,6 +142,15 @@ void spi_init0(void) {
     #endif
 }
 
+void spi_deinit_all(void) {
+    for (int i = 0; i < (sizeof(spi_obj) / sizeof(spi_t)); i++) {
+        const spi_t *spi = &spi_obj[i];
+        if (spi->spi != NULL) {
+            spi_deinit(spi);
+        }
+    }
+}
+
 int spi_find_index(mp_obj_t id) {
     if (mp_obj_is_str(id)) {
         // given a string id
@@ -386,6 +395,12 @@ void spi_init(const spi_t *self, bool enable_nss_pin) {
 }
 
 void spi_deinit(const spi_t *spi_obj) {
+    if (spi_obj->rx_dma_descr != NULL) {
+        dma_deinit(spi_obj->rx_dma_descr);
+    }
+    if (spi_obj->tx_dma_descr != NULL) {
+        dma_deinit(spi_obj->tx_dma_descr);
+    }
     SPI_HandleTypeDef *spi = spi_obj->spi;
     HAL_SPI_DeInit(spi);
     if (0) {

--- a/ports/stm32/spi.h
+++ b/ports/stm32/spi.h
@@ -74,6 +74,7 @@ extern const mp_obj_type_t machine_hard_spi_type;
 #define SPI_TRANSFER_TIMEOUT(len) ((len) + 100)
 
 void spi_init0(void);
+void spi_deinit_all(void);
 void spi_init(const spi_t *spi, bool enable_nss_pin);
 void spi_deinit(const spi_t *spi_obj);
 int spi_find_index(mp_obj_t id);


### PR DESCRIPTION
Fixes SPI/I2C DMA crash on soft reset.