### PR TITLE
Update omv.tf.rst

### DIFF
--- a/docs/library/omv.tf.rst
+++ b/docs/library/omv.tf.rst
@@ -11,7 +11,7 @@ You can read more about how to create your own models that can run on the
 OpenMV Cam `here <https://www.tensorflow.org/lite/microcontrollers>`__. In
 particular:
 
-   * Supported operations are listed `here <https://github.com/openmv/tensorflow/blob/master/tensorflow/lite/micro/kernels/all_ops_resolver.cc>`__.
+   * Supported operations are listed `here <https://github.com/openmv/tensorflow/blob/master/tensorflow/lite/micro/all_ops_resolver.cc>`__.
 
      * Note that tensorflow lite operations are versioned. If no version numbers
        are listed after the operation then the min and max version supported are


### PR DESCRIPTION
Upstream [commit](https://github.com/tensorflow/tensorflow/commit/e5dfc3bc38696060922b4d8a04d6e773467b9f08) changes the location of `all_ops_resolver.cc`.