### PR TITLE
Update quickref.rst

### DIFF
--- a/docs/openmvcam/quickref.rst
+++ b/docs/openmvcam/quickref.rst
@@ -29,7 +29,7 @@ Use the :mod:`time <utime>` module::
     utime.sleep_ms(500)      # sleep for 500 milliseconds
     utime.sleep_us(10)       # sleep for 10 microseconds
     start = utime.ticks_ms() # get value of millisecond counter
-    delta = utime.ticks_diff(time.ticks_ms(), start) # compute time difference
+    delta = utime.ticks_diff(utime.ticks_ms(), start) # compute time difference
 
 LEDs
 ----

--- a/docs/openmvcam/quickref.rst
+++ b/docs/openmvcam/quickref.rst
@@ -25,11 +25,11 @@ Use the :mod:`time <utime>` module::
 
     import utime
 
-    time.sleep(1)           # sleep for 1 second
-    time.sleep_ms(500)      # sleep for 500 milliseconds
-    time.sleep_us(10)       # sleep for 10 microseconds
-    start = time.ticks_ms() # get value of millisecond counter
-    delta = time.ticks_diff(time.ticks_ms(), start) # compute time difference
+    utime.sleep(1)           # sleep for 1 second
+    utime.sleep_ms(500)      # sleep for 500 milliseconds
+    utime.sleep_us(10)       # sleep for 10 microseconds
+    start = utime.ticks_ms() # get value of millisecond counter
+    delta = utime.ticks_diff(time.ticks_ms(), start) # compute time difference
 
 LEDs
 ----


### PR DESCRIPTION
Typo corrected where "time" module was used instead of "utime"