### PR TITLE
Change to OBJ REPR C to make floats the same size as ints

### DIFF
--- a/ports/stm32/mpconfigport.h
+++ b/ports/stm32/mpconfigport.h
@@ -440,13 +440,11 @@ struct _mp_bluetooth_btstack_root_pointers_t;
 
 #define MP_SSIZE_MAX (0x7fffffff)
 
-// Assume that if we already defined the obj repr then we also defined these items
-#ifndef MICROPY_OBJ_REPR
+#define MICROPY_OBJ_REPR            (MICROPY_OBJ_REPR_C)
 #define UINT_FMT "%u"
 #define INT_FMT "%d"
 typedef int mp_int_t; // must be pointer size
 typedef unsigned int mp_uint_t; // must be pointer size
-#endif
 
 typedef long mp_off_t;
 


### PR DESCRIPTION
Makes floats the same size as inits. This heavily reduces the size of floating point arrays.