### PR TITLE
Improve power savings by sleeping jpeg core

### DIFF
--- a/ports/stm32/boards/BORMIO/board_init.c
+++ b/ports/stm32/boards/BORMIO/board_init.c
@@ -23,8 +23,10 @@ void BORMIO_board_low_power(int mode)
 {
     switch (mode) {
         case 0:     // Leave stop mode.
+            __HAL_RCC_JPEG_CLK_SLEEP_DISABLE();
             break;
         case 1:     // Enter stop mode.
+            __HAL_RCC_JPEG_CLK_SLEEP_ENABLE();
             break;
         case 2:     // Enter standby mode.
             break;

--- a/ports/stm32/boards/OPENMV4P/board_init.c
+++ b/ports/stm32/boards/OPENMV4P/board_init.c
@@ -6,9 +6,11 @@ void board_low_power(int mode)
 {
     switch (mode) {
         case 0:     // Leave stop mode.
+            __HAL_RCC_JPEG_CLK_SLEEP_DISABLE();
             sdram_leave_low_power();
             break;
         case 1:     // Enter stop mode.
+            __HAL_RCC_JPEG_CLK_SLEEP_ENABLE();
             sdram_enter_low_power();
             break;
         case 2:     // Enter standby mode.

--- a/ports/stm32/boards/OPENMVPT/board_init.c
+++ b/ports/stm32/boards/OPENMVPT/board_init.c
@@ -6,9 +6,11 @@ void board_low_power(int mode)
 {
     switch (mode) {
         case 0:     // Leave stop mode.
+            __HAL_RCC_JPEG_CLK_SLEEP_DISABLE();
             sdram_leave_low_power();
             break;
         case 1:     // Enter stop mode.
+            __HAL_RCC_JPEG_CLK_SLEEP_ENABLE();
             sdram_enter_low_power();
             break;
         case 2:     // Enter standby mode.

--- a/ports/stm32/boards/PORTENTA/board_init.c
+++ b/ports/stm32/boards/PORTENTA/board_init.c
@@ -47,9 +47,11 @@ void PORTENTA_board_low_power(int mode)
 {
     switch (mode) {
         case 0:     // Leave stop mode.
+            __HAL_RCC_JPEG_CLK_SLEEP_DISABLE();
             sdram_leave_low_power();
             break;
         case 1:     // Enter stop mode.
+            __HAL_RCC_JPEG_CLK_SLEEP_ENABLE();
             sdram_enter_low_power();
             break;
         case 2:     // Enter standby mode.


### PR DESCRIPTION
Sleeps the JPEG core to save power.

Note: The OPENMV4 is missing low power config files. Please add and copy the same BORMIO settings to it.