### PR TITLE
Add MDMA pri level

### DIFF
--- a/ports/stm32/irq.h
+++ b/ports/stm32/irq.h
@@ -163,6 +163,8 @@ static inline void restore_irq_pri(uint32_t state) {
 // into the sdcard driver which waits for the DMA to complete.
 #define IRQ_PRI_DMA             NVIC_EncodePriority(NVIC_PRIORITYGROUP_4, 6, 0)
 
+#define IRQ_PRI_MDMA            NVIC_EncodePriority(NVIC_PRIORITYGROUP_4, 7, 0)
+
 #define IRQ_PRI_OTG_FS          NVIC_EncodePriority(NVIC_PRIORITYGROUP_4, 7, 0)
 
 #define IRQ_PRI_OTG_HS          NVIC_EncodePriority(NVIC_PRIORITYGROUP_4, 7, 0)


### PR DESCRIPTION
Selected a level of 7. It needs to be greater than JPEG priority (5) and since I will use regular DMAs in the future to trigger it then it should be at a higher level than DMA too.