### PR TITLE
Add buzzer module

### DIFF
--- a/ports/nrf/mpconfigport.h
+++ b/ports/nrf/mpconfigport.h
@@ -282,6 +282,12 @@ extern const struct _mp_obj_module_t tv_module;
 #else
 #define TV_BUILTIN_MODULE
 #endif
+#if MICROPY_PY_BUZZER
+extern const struct _mp_obj_module_t buzzer_module;
+#define BUZZER_BUILTIN_MODULE           {  MP_ROM_QSTR(MP_QSTR_buzzer), MP_ROM_PTR(&buzzer_module) },
+#else
+#define BUZZER_BUILTIN_MODULE
+#endif
 
 #if MICROPY_PY_SENSOR
 extern const struct _mp_obj_module_t sensor_module;
@@ -302,6 +308,7 @@ extern const struct _mp_obj_module_t sensor_module;
     AUDIO_BUILTIN_MODULE \
     LCD_BUILTIN_MODULE \
     TV_BUILTIN_MODULE \
+    BUZZER_BUILTIN_MODULE \
     SENSOR_BUILTIN_MODULE \
     BLE_MODULE \
     MUSIC_MODULE \

--- a/ports/stm32/mpconfigport.h
+++ b/ports/stm32/mpconfigport.h
@@ -270,6 +270,9 @@ extern const struct _mp_obj_module_t tf_module;
 #if MICROPY_PY_TV
 extern const struct _mp_obj_module_t tv_module;
 #endif
+#if MICROPY_PY_BUZZER
+extern const struct _mp_obj_module_t buzzer_module;
+#endif
 extern const struct _mp_obj_module_t nn_st_module;
 #if MICROPY_PY_ULAB
 extern const struct _mp_obj_module_t ulab_user_cmodule;
@@ -361,6 +364,12 @@ extern const struct _mp_obj_module_t micro_speech_module;
 #define TV_BUILTIN_MODULE
 #endif
 
+#if MICROPY_PY_BUZZER
+#define BUZZER_BUILTIN_MODULE           {  MP_ROM_QSTR(MP_QSTR_buzzer), MP_ROM_PTR(&buzzer_module) },
+#else
+#define BUZZER_BUILTIN_MODULE
+#endif
+
 #define MICROPY_PORT_BUILTIN_MODULES \
     { MP_OBJ_NEW_QSTR(MP_QSTR_umachine), (mp_obj_t)&machine_module }, \
     { MP_OBJ_NEW_QSTR(MP_QSTR_pyb), (mp_obj_t)&pyb_module }, \
@@ -378,6 +387,7 @@ extern const struct _mp_obj_module_t micro_speech_module;
     { MP_OBJ_NEW_QSTR(MP_QSTR_cpufreq), (mp_obj_t)&cpufreq_module }, \
     { MP_OBJ_NEW_QSTR(MP_QSTR_tf),      (mp_obj_t)&tf_module }, \
     TV_BUILTIN_MODULE \
+    BUZZER_BUILTIN_MODULE \
     CUBEAI_BUILTIN_MODULE \
     ULAB_BUILTIN_MODULE \
     IMU_BUILTIN_MODULE \


### PR DESCRIPTION
Adds support for the buzzer module.

This is on the OpenMV PT and new Portenta Shield.