### PR TITLE
mimxrt/OPENMV_RT1060: Fix wifi alt pin config.

### DIFF
--- a/ports/mimxrt/boards/OPENMV_RT1060/mpconfigboard.h
+++ b/ports/mimxrt/boards/OPENMV_RT1060/mpconfigboard.h
@@ -48,6 +48,13 @@ extern void mimxrt_hal_bootloader(void);
 #define MICROPY_HW_BT_HOST_WAKE     (&pin_GPIO_AD_B0_14)
 #define MICROPY_HW_BT_DEV_WAKE      (&pin_GPIO_SD_B1_00)
 
+#define MICROPY_HW_SDIO_CLK_ALT     (6)
+#define MICROPY_HW_SDIO_CMD_ALT     (6)
+#define MICROPY_HW_SDIO_D0_ALT      (0)
+#define MICROPY_HW_SDIO_D1_ALT      (0)
+#define MICROPY_HW_SDIO_D2_ALT      (6)
+#define MICROPY_HW_SDIO_D3_ALT      (6)
+
 // Bluetooth config.
 #define MICROPY_HW_BLE_UART_ID          (1)
 #define MICROPY_HW_BLE_UART_BASE        (LPUART3)


### PR DESCRIPTION
D0 and D1 alts were at 6 and need to be 0.