### PR TITLE
ports/mimxrt: Add support for deepsleep.

### DIFF
--- a/ports/mimxrt/machine_rtc.c
+++ b/ports/mimxrt/machine_rtc.c
@@ -25,15 +25,118 @@
  * THE SOFTWARE.
  */
 
+#include "py/mperrno.h"
 #include "py/runtime.h"
+#include "shared/runtime/mpirq.h"
 #include "shared/timeutils/timeutils.h"
 #include "modmachine.h"
 #include "ticks.h"
 #include "fsl_snvs_lp.h"
 
+STATIC mp_int_t timeout = 0;
+
+void machine_rtc_alarm_clear_en() {
+    SNVS_LP_SRTC_DisableInterrupts(SNVS, SNVS_LPCR_LPTA_EN_MASK);
+    while (SNVS->LPCR & SNVS_LPCR_LPTA_EN_MASK) {
+        ;
+    }
+}
+
+void machine_rtc_alarm_set_en() {
+    SNVS_LP_SRTC_EnableInterrupts(SNVS, SNVS_LPCR_LPTA_EN_MASK);
+    while (!(SNVS->LPCR & SNVS_LPCR_LPTA_EN_MASK)) {
+        ;
+    }
+}
+
+void machine_rtc_alarm_off(bool clear) {
+    machine_rtc_alarm_clear_en();
+    DisableIRQ(SNVS_HP_WRAPPER_IRQn);
+
+    if (clear) {
+        SNVS->LPTAR = 0;
+        timeout = 0;
+        SNVS->LPSR = SNVS_LPSR_LPTA_MASK;
+    }
+}
+
+void machine_rtc_alarm_on() {
+    EnableIRQ(SNVS_HP_WRAPPER_IRQn);
+    machine_rtc_alarm_set_en();
+}
+
+uint32_t machine_rtc_get_seconds() {
+    uint32_t seconds = 0;
+    uint32_t tmp = 0;
+
+    // Do consecutive reads until value is correct
+    do {
+        seconds = tmp;
+        tmp = (SNVS->LPSRTCMR << 17U);
+        tmp |= (SNVS->LPSRTCLR >> 15U);
+    } while (tmp != seconds);
+
+    return seconds;
+}
+
+void machine_rtc_alarm_helper(int seconds, bool repeat) {
+    machine_rtc_alarm_off(true);
+
+    SNVS->LPTAR = machine_rtc_get_seconds() + seconds;
+
+    if (repeat) {
+        timeout = seconds;
+    }
+
+    machine_rtc_alarm_on();
+}
+
+typedef struct _machine_rtc_irq_obj_t {
+    mp_irq_obj_t base;
+} machine_rtc_irq_obj_t;
+
+STATIC mp_uint_t machine_rtc_irq_trigger(mp_obj_t self_in, mp_uint_t new_trigger) {
+    new_trigger /= 1000;
+    if (!new_trigger) {
+        machine_rtc_alarm_off(true);
+    } else {
+        machine_rtc_alarm_helper(new_trigger, true);
+    }
+    return 0;
+}
+
+STATIC mp_uint_t machine_rtc_irq_info(mp_obj_t self_in, mp_uint_t info_type) {
+    return 0;
+}
+
+STATIC const mp_irq_methods_t machine_rtc_irq_methods = {
+    .trigger = machine_rtc_irq_trigger,
+    .info = machine_rtc_irq_info,
+};
+
+void SNVS_HP_WRAPPER_IRQHandler(void) {
+    if (SNVS->LPSR & SNVS_LPSR_LPTA_MASK) {
+        SNVS->LPSR = SNVS_LPSR_LPTA_MASK;
+        machine_rtc_irq_obj_t *irq = MP_STATE_PORT(machine_rtc_irq_object);
+        if (irq != NULL) {
+            mp_irq_handler(&irq->base);
+        }
+        if (timeout > 0) {
+            machine_rtc_alarm_clear_en();
+            SNVS->LPTAR += timeout;
+            machine_rtc_alarm_set_en();
+        }
+    }
+}
+
+// Deinit rtc IRQ handler.
+void machine_rtc_irq_deinit(void) {
+    machine_rtc_alarm_off(true);
+    MP_STATE_PORT(machine_rtc_irq_object) = NULL;
+}
+
 typedef struct _machine_rtc_obj_t {
     mp_obj_base_t base;
-    mp_obj_t callback;
 } machine_rtc_obj_t;
 
 // Singleton RTC object.
@@ -156,11 +259,158 @@ STATIC mp_obj_t machine_rtc_calibration(mp_obj_t self_in, mp_obj_t cal_in) {
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_2(machine_rtc_calibration_obj, machine_rtc_calibration);
 
+STATIC mp_obj_t machine_rtc_alarm(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+    STATIC const mp_arg_t allowed_args[] = {
+        { MP_QSTR_id,                            MP_ARG_INT,  {.u_int = 0} },
+        { MP_QSTR_time,                          MP_ARG_OBJ,  {.u_obj = mp_const_none} },
+        { MP_QSTR_repeat,     MP_ARG_KW_ONLY | MP_ARG_BOOL, {.u_bool = false} },
+    };
+
+    mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
+    mp_arg_parse_all(n_args - 1, pos_args + 1, kw_args, MP_ARRAY_SIZE(args), allowed_args, args);
+
+    // check the alarm id
+    if (args[0].u_int != 0) {
+        mp_raise_OSError(MP_ENODEV);
+    }
+
+    mp_int_t seconds = 0;
+    snvs_lp_srtc_datetime_t srtc_date;
+    bool repeat = args[2].u_bool;
+    if (mp_obj_is_type(args[1].u_obj, &mp_type_tuple)) { // datetime tuple given
+        // repeat cannot be used with a datetime tuple
+        if (repeat) {
+            mp_raise_ValueError(MP_ERROR_TEXT("invalid argument(s) value"));
+        }
+        // Set date and time.
+        mp_obj_t *items;
+        mp_int_t year;
+        mp_obj_get_array_fixed_n(args[1].u_obj, 8, &items);
+
+        year = mp_obj_get_int(items[0]);
+        srtc_date.year = year >= 100 ? year : year + 2000; // allow 21 for 2021
+        srtc_date.month = mp_obj_get_int(items[1]);
+        srtc_date.day = mp_obj_get_int(items[2]);
+        // Ignore weekday at items[3]
+        srtc_date.hour = mp_obj_get_int(items[4]);
+        srtc_date.minute = mp_obj_get_int(items[5]);
+        srtc_date.second = mp_obj_get_int(items[6]);
+        machine_rtc_alarm_off(true);
+        if (SNVS_LP_SRTC_SetAlarm(SNVS, &srtc_date) != kStatus_Success) {
+            mp_raise_ValueError(NULL);
+        }
+        machine_rtc_alarm_on();
+    } else { // then it must be an integer
+        seconds = (args[1].u_obj == mp_const_none) ? 0 : (mp_obj_get_int(args[1].u_obj) / 1000);
+        machine_rtc_alarm_helper(seconds, repeat);
+    }
+
+    return mp_const_none;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_KW(machine_rtc_alarm_obj, 1, machine_rtc_alarm);
+
+STATIC mp_obj_t machine_rtc_alarm_left(size_t n_args, const mp_obj_t *args) {
+    // only alarm id 0 is available
+    if (n_args > 1 && mp_obj_get_int(args[1]) != 0) {
+        mp_raise_OSError(MP_ENODEV);
+    }
+    uint32_t seconds = machine_rtc_get_seconds();
+    uint32_t alarmSeconds = SNVS->LPTAR;
+    return mp_obj_new_int((alarmSeconds >= seconds) ? ((alarmSeconds - seconds) * 1000) : 0);
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(machine_rtc_alarm_left_obj, 1, 2, machine_rtc_alarm_left);
+
+STATIC mp_obj_t machine_rtc_alarm_cancel(size_t n_args, const mp_obj_t *args) {
+    // only alarm id 0 is available
+    if (n_args > 1 && mp_obj_get_int(args[1]) != 0) {
+        mp_raise_OSError(MP_ENODEV);
+    }
+    machine_rtc_alarm_off(true);
+    return mp_const_none;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(machine_rtc_alarm_cancel_obj, 1, 2, machine_rtc_alarm_cancel);
+
+STATIC mp_obj_t machine_rtc_irq(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+    enum { ARG_trigger, ARG_handler, ARG_wake };
+    static const mp_arg_t allowed_args[] = {
+        { MP_QSTR_trigger, MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = 0} },
+        { MP_QSTR_handler, MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_obj = mp_const_none} },
+        { MP_QSTR_wake, MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = 0} },
+    };
+
+    mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
+    mp_arg_parse_all(n_args - 1, pos_args + 1, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
+
+    // check we want alarm0
+    if (args[ARG_trigger].u_int != 0) {
+        mp_raise_OSError(MP_ENODEV);
+    }
+
+    machine_rtc_irq_obj_t *irq = MP_STATE_PORT(machine_rtc_irq_object);
+
+    // Allocate the IRQ object if it doesn't already exist.
+    if (irq == NULL) {
+        irq = m_new_obj(machine_rtc_irq_obj_t);
+        irq->base.base.type = &mp_irq_type;
+        irq->base.methods = (mp_irq_methods_t *)&machine_rtc_irq_methods;
+        irq->base.parent = MP_OBJ_FROM_PTR(pos_args[0]);
+        irq->base.handler = mp_const_none;
+        irq->base.ishard = true;
+        MP_STATE_PORT(machine_rtc_irq_object) = irq;
+    }
+
+    machine_rtc_alarm_off(false);
+
+    irq->base.handler = args[ARG_handler].u_obj;
+
+    if (SNVS->LPTAR) {
+        machine_rtc_alarm_on();
+    }
+
+    return MP_OBJ_FROM_PTR(irq);
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_KW(machine_rtc_irq_obj, 1, machine_rtc_irq);
+
+STATIC mp_obj_t machine_rtc_wakeup(size_t n_args, const mp_obj_t *args) {
+    mp_int_t seconds = (args[1] == mp_const_none) ? 0 : (mp_obj_get_int(args[1]) / 1000);
+
+    machine_rtc_alarm_off(true);
+
+    machine_rtc_irq_obj_t *irq = MP_STATE_PORT(machine_rtc_irq_object);
+
+    // Allocate the IRQ object if it doesn't already exist.
+    if (irq == NULL) {
+        irq = m_new_obj(machine_rtc_irq_obj_t);
+        irq->base.base.type = &mp_irq_type;
+        irq->base.methods = (mp_irq_methods_t *)&machine_rtc_irq_methods;
+        irq->base.parent = MP_OBJ_FROM_PTR(args[0]);
+        irq->base.handler = mp_const_none;
+        irq->base.ishard = true;
+        MP_STATE_PORT(machine_rtc_irq_object) = irq;
+    }
+
+    irq->base.handler = (n_args > 2) ? args[2] : mp_const_none;
+
+    if (seconds > 0) {
+        machine_rtc_alarm_helper(seconds, true);
+    }
+
+    return mp_const_none;
+}
+MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(machine_rtc_wakeup_obj, 2, 3, machine_rtc_wakeup);
+
 STATIC const mp_rom_map_elem_t machine_rtc_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_init), MP_ROM_PTR(&machine_rtc_init_obj) },
     { MP_ROM_QSTR(MP_QSTR_datetime), MP_ROM_PTR(&machine_rtc_datetime_obj) },
     { MP_ROM_QSTR(MP_QSTR_now), MP_ROM_PTR(&machine_rtc_now_obj) },
     { MP_ROM_QSTR(MP_QSTR_calibration), MP_ROM_PTR(&machine_rtc_calibration_obj) },
+    { MP_ROM_QSTR(MP_QSTR_alarm), MP_ROM_PTR(&machine_rtc_alarm_obj) },
+    { MP_ROM_QSTR(MP_QSTR_alarm_left), MP_ROM_PTR(&machine_rtc_alarm_left_obj) },
+    { MP_ROM_QSTR(MP_QSTR_alarm_cancel), MP_ROM_PTR(&machine_rtc_alarm_cancel_obj) },
+    { MP_ROM_QSTR(MP_QSTR_cancel), MP_ROM_PTR(&machine_rtc_alarm_cancel_obj) },
+    { MP_ROM_QSTR(MP_QSTR_irq), MP_ROM_PTR(&machine_rtc_irq_obj) },
+    { MP_ROM_QSTR(MP_QSTR_wakeup), MP_ROM_PTR(&machine_rtc_wakeup_obj) },
+    { MP_ROM_QSTR(MP_QSTR_ALARM0), MP_ROM_INT(0) },
 };
 STATIC MP_DEFINE_CONST_DICT(machine_rtc_locals_dict, machine_rtc_locals_dict_table);
 
@@ -171,3 +421,5 @@ MP_DEFINE_CONST_OBJ_TYPE(
     make_new, machine_rtc_make_new,
     locals_dict, &machine_rtc_locals_dict
     );
+
+MP_REGISTER_ROOT_POINTER(void *machine_rtc_irq_object);

--- a/ports/mimxrt/main.c
+++ b/ports/mimxrt/main.c
@@ -140,6 +140,7 @@ int main(void) {
     soft_reset_exit:
         mp_printf(MP_PYTHON_PRINTER, "MPY: soft reboot\n");
         machine_pin_irq_deinit();
+        machine_rtc_irq_deinit();
         #if MICROPY_PY_MACHINE_I2S
         machine_i2s_deinit_all();
         #endif

--- a/ports/mimxrt/modmachine.h
+++ b/ports/mimxrt/modmachine.h
@@ -42,6 +42,7 @@ extern const mp_obj_type_t machine_wdt_type;
 
 void machine_adc_init(void);
 void machine_pin_irq_deinit(void);
+void machine_rtc_irq_deinit(void);
 void machine_pwm_deinit_all(void);
 void machine_timer_init_PIT(void);
 void machine_sdcard_init0(void);


### PR DESCRIPTION
This PR requires: https://github.com/openmv/micropython/pull/109 to be merged first.

Anyway, this is a fully functional deep sleep implementation. On the OpenMV Cam RT1060 it drops power consumption down to 30uA. It supports wakeup via a previously running RTC timer, the wakeup pin (rising edge), or you can pass a time value and the system will delay that long and then wakeup then.

As for lightsleep. That implementation is much harder to do as you have to turn off clocks and then turn them back on. I have working code for the RT1060 from the SDK. See the project power_mode_switch_bm. However, after trying to integrate the lpm.c/specific.c files which have the power control functionality I was not able to get the SoC to wakeup successfully. So, implementation of lightsleep is going to be likely a painful task of figuring out what can be done safely and etc.