### PR TITLE
ports/mimxrt/OPENMV_RT1060: Remove pull ups and increase sd clock dri…

### DIFF
--- a/ports/mimxrt/boards/OPENMV_RT1060/mpconfigboard.h
+++ b/ports/mimxrt/boards/OPENMV_RT1060/mpconfigboard.h
@@ -146,6 +146,10 @@ extern void mimxrt_hal_bootloader(void);
         .data3 = { GPIO_SD_B0_05_USDHC1_DATA3 }, \
     }
 
+// Override the default USDHC pin config.
+#define USDHC_PULL_UPS_ON_BOARD (1)
+#define USDHC_CLK_PIN_DRIVE     (PIN_DRIVE_4)
+
 // --- SEMC --- //
 #define MIMXRT_IOMUXC_SEMC_DATA00 IOMUXC_GPIO_EMC_00_SEMC_DATA00
 #define MIMXRT_IOMUXC_SEMC_DATA01 IOMUXC_GPIO_EMC_01_SEMC_DATA01

--- a/ports/mimxrt/sdcard.c
+++ b/ports/mimxrt/sdcard.c
@@ -745,8 +745,22 @@ void sdcard_init_pins(mimxrt_sdcard_obj_t *card) {
     // speed and strength optimized for clock frequency < 100MHz
     const mimxrt_sdcard_obj_pins_t *pins = card->pins;
 
+    #if USDHC_PULL_UPS_ON_BOARD
+    uint32_t pin_pull = PIN_PULL_DISABLED;
+    #else
+    uint32_t pin_pull = PIN_PULL_UP_47K;
+    #endif
+
+    #ifdef USDHC_CLK_PIN_DRIVE
+    uint32_t clk_pin_drive = USDHC_CLK_PIN_DRIVE;
+    #else
+    uint32_t clk_pin_drive = PIN_DRIVE_6;
+    #endif
+
     uint32_t default_config = pin_generate_config(
-        PIN_PULL_UP_47K, PIN_MODE_SKIP, PIN_DRIVE_6, card->pins->clk.pin->configRegister);
+        pin_pull, PIN_MODE_SKIP, PIN_DRIVE_6, card->pins->clk.pin->configRegister);
+    uint32_t clock_config = pin_generate_config(
+        PIN_PULL_UP_47K, PIN_MODE_SKIP, clk_pin_drive, card->pins->clk.pin->configRegister);
     #if USDHC_DATA3_PULL_DOWN_ON_BOARD
     // Pull down on the board -> must not enable internal PD.
     uint32_t no_cd_config = pin_generate_config(
@@ -756,7 +770,7 @@ void sdcard_init_pins(mimxrt_sdcard_obj_t *card) {
         PIN_PULL_DOWN_100K, PIN_MODE_SKIP, PIN_DRIVE_6, card->pins->data3.pin->configRegister);
     #endif // USDHC_DATA3_PULL_DOWN_ON_BOARD
 
-    sdcard_init_pin(card->pins->clk.pin, card->pins->clk.af_idx, default_config);  // USDHC1_CLK
+    sdcard_init_pin(card->pins->clk.pin, card->pins->clk.af_idx, clock_config);  // USDHC1_CLK
     sdcard_init_pin(card->pins->cmd.pin, card->pins->cmd.af_idx, default_config);  // USDHC1_CMD
     sdcard_init_pin(card->pins->data0.pin, card->pins->data0.af_idx, default_config);  // USDHC1_DATA0
     sdcard_init_pin(card->pins->data1.pin, card->pins->data1.af_idx, default_config);  // USDHC1_DATA1


### PR DESCRIPTION
On V3 of the OpenMV Cam RT there is an issue with the impedance of the SD card pins. This fixes that issue by removing the pull ups on inside the processor which increase pin loading (two 100k resistors in parallel) and then increases the SD card clk drive strength to have cleaner edges.

That said... I tested this fix on our other prototypes which did not need this change and it breaks them. As such, this PR is just a solution our final board design if needed.

...

Long term fixes would be to make the SD card drive gracefully handle bit error on the SD card bus as it's CRC protected. So, a transaction could just be replayed. However, such code would need to be added to the HAL. The micropython driver assumes transactions are accomplished or fail per call.