### PR TITLE
py: Wrap call with fb_alloc.

### DIFF
--- a/py/omvdummy.c
+++ b/py/omvdummy.c
@@ -3,14 +3,17 @@
  */
 
 /*
- * This function is doesn't to do anything.
- * It stay here to prevent the error when compiling 
- * a frozen module on openmv platform.
- * It declared as weak function and when all compiled 
- * objects have been linked, it will override by 
- * the real 'fb_alloc_free_till_mark' function 
- * which in 'fb_alloc.c' files
+ * These functions don't to do anything.
+ * They are here to prevent an error when compiling
+ * a frozen module on the openmv platform.
+ * They are declared as weak functions and when all compiled
+ * objects have been linked, they will overridden by
+ * the real 'fb_alloc_mark' and 'fb_alloc_free_till_mark'
+ * functions in the 'fb_alloc.c' file.
  */
+void __attribute__((weak)) fb_alloc_mark()
+{
+}
 void __attribute__((weak)) fb_alloc_free_till_mark()
 {
 }

--- a/py/runtime.c
+++ b/py/runtime.c
@@ -692,7 +692,12 @@ mp_obj_t mp_call_function_n_kw(mp_obj_t fun_in, size_t n_args, size_t n_kw, cons
 
     // do the call
     if (MP_OBJ_TYPE_HAS_SLOT(type, call)) {
-        return MP_OBJ_TYPE_GET_SLOT(type, call)(fun_in, n_args, n_kw, args);
+        extern void fb_alloc_mark();
+        extern void fb_alloc_free_till_mark();
+        fb_alloc_mark();
+        mp_obj_t result = MP_OBJ_TYPE_GET_SLOT(type, call)(fun_in, n_args, n_kw, args);
+        fb_alloc_free_till_mark();
+        return result;
     }
 
     #if MICROPY_ERROR_REPORTING <= MICROPY_ERROR_REPORTING_TERSE


### PR DESCRIPTION
This wraps fb_alloc around all functions/methods being called... so, it's not necessary to protect context anywhere else.

That said, it probably doesn't make sense to do this. fb_alloc_mark does a bunch of stuff and would slow down function calls. It's sensible probably just to keep wrapping image processing functions manually.

Anyway, just made the PR to show the code. Probably should close it.