### PR TITLE
extmod/modmachine: Re-enable MIMXRT CAN.

### DIFF
--- a/extmod/modmachine.c
+++ b/extmod/modmachine.c
@@ -203,6 +203,9 @@ STATIC const mp_rom_map_elem_t machine_module_globals_table[] = {
     #if MICROPY_PY_MACHINE_ADC_BLOCK
     { MP_ROM_QSTR(MP_QSTR_ADCBlock), MP_ROM_PTR(&machine_adc_block_type) },
     #endif
+    #if MICROPY_PY_MACHINE_CAN
+    { MP_ROM_QSTR(MP_QSTR_CAN), MP_ROM_PTR(&machine_can_type) },
+    #endif
     #if MICROPY_PY_MACHINE_DAC
     { MP_ROM_QSTR(MP_QSTR_DAC), MP_ROM_PTR(&machine_dac_type) },
     #endif


### PR DESCRIPTION
It got broken it appears in the rebase. Issue pointed out by customer emailing.