### PR TITLE
ports/stm32: Fix print overload crash on stop.

### DIFF
--- a/ports/stm32/usbd_cdc_interface.c
+++ b/ports/stm32/usbd_cdc_interface.c
@@ -73,6 +73,7 @@
 #define IDE_BAUDRATE_SLOW    (921600)
 #define IDE_BAUDRATE_FAST    (12000000)
 
+extern bool usbdbg_get_irq_enabled();
 extern void usbdbg_data_in(void *buffer, int length);
 extern void usbdbg_data_out(void *buffer, int length);
 extern void usbdbg_control(void *buffer, uint8_t brequest, uint32_t wlength);
@@ -456,7 +457,7 @@ int usbd_cdc_tx(usbd_cdc_itf_t *cdc, const uint8_t *buf, uint32_t len, uint32_t 
                 // timeout
                 return i;
             }
-            if (query_irq() == IRQ_STATE_DISABLED) {
+            if ((query_irq() == IRQ_STATE_DISABLED) || (!usbdbg_get_irq_enabled())) {
                 // IRQs disabled so buffer will never be drained; return immediately
                 return i;
             }
@@ -493,7 +494,7 @@ void usbd_cdc_tx_always(usbd_cdc_itf_t *cdc, const uint8_t *buf, uint32_t len) {
                     // The USB is suspended so buffer will never be drained; exit loop
                     break;
                 }
-                if (query_irq() == IRQ_STATE_DISABLED) {
+                if ((query_irq() == IRQ_STATE_DISABLED) || (!usbdbg_get_irq_enabled())) {
                     // IRQs disabled so buffer will never be drained; exit loop
                     break;
                 }
@@ -537,7 +538,7 @@ int usbd_cdc_rx(usbd_cdc_itf_t *cdc, uint8_t *buf, uint32_t len, uint32_t timeou
                 // timeout
                 return i;
             }
-            if (query_irq() == IRQ_STATE_DISABLED) {
+            if ((query_irq() == IRQ_STATE_DISABLED) || (!usbdbg_get_irq_enabled())) {
                 // IRQs disabled so buffer will never be filled; return immediately
                 return i;
             }


### PR DESCRIPTION
Because the new VM abort feature doesn't instantly kill running C code anymore on stop... a script that's generating a large amount of print output will continue to fill the CDC buffers even after the script has been stopped and the USB IRQ is turned off.

When this happens usbd_cdc_tx_always() will get stuck for 500ms a character at a time time from the print output. While the camera has not technically crashed... it will fall off the USB bus and generally become unresponsive.

This fix causes the loop to exit using the same conditions already built-into the code right now.