### PR TITLE
ports/stm32: Move JPEG priority down to 10.

### DIFF
--- a/ports/stm32/irq.h
+++ b/ports/stm32/irq.h
@@ -158,9 +158,6 @@ static inline void restore_irq_pri(uint32_t state) {
 // DCMI DMA2_Stream1
 #define IRQ_PRI_DMA21           NVIC_EncodePriority(NVIC_PRIORITYGROUP_4, 3, 0)
 
-// F7 JPEG encoder
-#define IRQ_PRI_JPEG            NVIC_EncodePriority(NVIC_PRIORITYGROUP_4, 4, 0)
-
 // SDIO must be higher priority than DMA for SDIO DMA transfers to work.
 #define IRQ_PRI_SDIO            NVIC_EncodePriority(NVIC_PRIORITYGROUP_4, 4, 0)
 
@@ -190,6 +187,8 @@ static inline void restore_irq_pri(uint32_t state) {
 #define IRQ_PRI_DSI             NVIC_EncodePriority(NVIC_PRIORITYGROUP_4, 10, 0)
 
 #define IRQ_PRI_HSEM            NVIC_EncodePriority(NVIC_PRIORITYGROUP_4, 10, 0)
+
+#define IRQ_PRI_JPEG            NVIC_EncodePriority(NVIC_PRIORITYGROUP_4, 10, 0)
 
 // Interrupt priority for non-special timers.
 #define IRQ_PRI_TIMX            NVIC_EncodePriority(NVIC_PRIORITYGROUP_4, 13, 0)


### PR DESCRIPTION
This fixes the jpeg encoder eating up all the bandwidth in interrupt mode.

Moving SPI priority around for the FLIR doesn't matter as when the SPI bus is in circular mode it never stops clocking so it doesn't generate any interrupts. Everything is controlled via the DMA half/full transfer complete interrupts in this case.