### PR TITLE
Kwabena/fix portenta ethernet dma buffer

### DIFF
--- a/ports/stm32/boards/ARDUINO_PORTENTA_H7/mpconfigboard.h
+++ b/ports/stm32/boards/ARDUINO_PORTENTA_H7/mpconfigboard.h
@@ -325,6 +325,8 @@ extern struct _spi_bdev_t spi_bdev;
 #define MICROPY_HW_ETH_RMII_TXD0    (pin_G13)
 #define MICROPY_HW_ETH_RMII_TXD1    (pin_G12)
 
+#define MICROPY_HW_ETH_DMA_ATTR_SECTION         __attribute__((section(".dma_buffer")))
+
 #define MICROPY_HW_USB_VID                      0x2341
 #define MICROPY_HW_USB_PID                      0x045B
 #define MICROPY_HW_USB_PID_CDC_MSC              (MICROPY_HW_USB_PID)

--- a/ports/stm32/eth.c
+++ b/ports/stm32/eth.c
@@ -121,7 +121,11 @@ typedef struct _eth_t {
     int16_t (*phy_get_link_status)(uint32_t phy_addr);
 } eth_t;
 
+#ifdef MICROPY_HW_ETH_DMA_ATTR_SECTION
+static eth_dma_t eth_dma __attribute__((aligned(16384))) MICROPY_HW_ETH_DMA_ATTR_SECTION;
+#else
 static eth_dma_t eth_dma __attribute__((aligned(16384)));
+#endif
 
 eth_t eth_instance;
 


### PR DESCRIPTION
On the Arduino Portenta H7 OpenMV port, the default memory location was set to the DTCM, which is not accessible by the ETH controller. These changes move it to the DMA memory pool.