### PR TITLE
ports/mimxrt: Update RT1060 USB PID/VID.

### DIFF
--- a/ports/mimxrt/boards/OPENMV_RT1060/mpconfigboard.h
+++ b/ports/mimxrt/boards/OPENMV_RT1060/mpconfigboard.h
@@ -21,8 +21,8 @@ extern void mimxrt_hal_bootloader(void);
 #define MICROPY_PY_MACHINE_CAN      (1)
 
 #define MICROPY_HW_USB_MSC          (1)
-#define MICROPY_HW_USB_VID          0x1209
-#define MICROPY_HW_USB_PID          0xabd1
+#define MICROPY_HW_USB_VID          0x37c5
+#define MICROPY_HW_USB_PID          0x1060
 
 #define MICROPY_HW_LED1_PIN         (pin_GPIO_B0_10)
 #define MICROPY_HW_LED2_PIN         (pin_GPIO_B0_11)

--- a/ports/mimxrt/boards/OPENMV_RT1060/mpconfigboard.h
+++ b/ports/mimxrt/boards/OPENMV_RT1060/mpconfigboard.h
@@ -242,3 +242,8 @@ extern void mimxrt_hal_bootloader(void);
     { IOMUXC_GPIO_B1_11_ENET_RX_ER, 0, 0xB0E9u }, \
     { IOMUXC_GPIO_EMC_41_ENET_MDIO, 0, 0xB0E9u }, \
     { IOMUXC_GPIO_EMC_40_ENET_MDC, 0, 0xB0E9u },
+
+// USB CDC config
+#define CFG_TUD_CDC_EP_BUFSIZE  (4096)
+#define CFG_TUD_CDC_RX_BUFSIZE  (4096)
+#define CFG_TUD_CDC_TX_BUFSIZE  (4096)


### PR DESCRIPTION
* Updates the board USB VID/PID from the FOSS one to our private one.
* Increases USB buffer sizes to match the AE3 for the best USB CDC performance.
